### PR TITLE
 DatePicker: Java8-examples: add timeInput (new PR)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.primefaces</groupId>
     <artifactId>showcase</artifactId>
-    <version>8.0-SNAPSHOT</version>
+    <version>9.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>primefaces-showcase</name>
@@ -317,13 +317,13 @@
             </activation>
             <properties>
                 <jsfVersion>Mojarra-${mojarra.version}</jsfVersion>
-                <primefacesVersion>PrimeFaces-8.0-SNAPSHOT</primefacesVersion>
+                <primefacesVersion>PrimeFaces-9.0-SNAPSHOT</primefacesVersion>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.primefaces</groupId>
                     <artifactId>primefaces</artifactId>
-                    <version>8.0-SNAPSHOT</version>
+                    <version>9.0-SNAPSHOT</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish</groupId>
@@ -341,13 +341,13 @@
             <id>dev-myfaces</id>
             <properties>
                 <jsfVersion>Apache MyFaces-${myfaces.version}</jsfVersion>
-                <primefacesVersion>PrimeFaces-8.0-SNAPSHOT</primefacesVersion>
+                <primefacesVersion>PrimeFaces-9.0-SNAPSHOT</primefacesVersion>
             </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.primefaces</groupId>
                     <artifactId>primefaces</artifactId>
-                    <version>8.0-SNAPSHOT</version>
+                    <version>9.0-SNAPSHOT</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.myfaces.core</groupId>

--- a/src/main/java/org/primefaces/showcase/view/input/CalendarJava8View.java
+++ b/src/main/java/org/primefaces/showcase/view/input/CalendarJava8View.java
@@ -33,6 +33,9 @@ import java.util.List;
 @ViewScoped
 public class CalendarJava8View implements Serializable {
 
+    private Boolean timeInput = Boolean.FALSE;
+    private Boolean showOtherMonths = Boolean.FALSE;
+
     private LocalDate date1;
     private LocalDate date2;
     private LocalDate date3;
@@ -97,7 +100,7 @@ public class CalendarJava8View implements Serializable {
         dateTimeDe = LocalDateTime.of(2019, 7, 27, 12, 59);
         dateTime4 = LocalDateTime.now();
 
-        time4= LocalTime.of(6, 30);
+        time4= LocalTime.of(10, 30);
     }
 
     public void onDateSelect(SelectEvent<LocalDate> event) {
@@ -413,5 +416,21 @@ public class CalendarJava8View implements Serializable {
 
     public void setDateTime5(LocalDateTime dateTime5) {
         this.dateTime5 = dateTime5;
+    }
+
+    public Boolean getTimeInput() {
+        return timeInput;
+    }
+
+    public void setTimeInput(Boolean timeInput) {
+        this.timeInput = timeInput;
+    }
+
+    public Boolean getShowOtherMonths() {
+        return showOtherMonths;
+    }
+
+    public void setShowOtherMonths(Boolean showOtherMonths) {
+        this.showOtherMonths = showOtherMonths;
     }
 }

--- a/src/main/webapp/WEB-INF/menu.xhtml
+++ b/src/main/webapp/WEB-INF/menu.xhtml
@@ -230,13 +230,13 @@
                             </ul>
                             <ul style="width:37%">
                                 <li>
-                                    <h:link outcome="/ui/input/datepicker/datePicker">
+                                    <h:link outcome="/ui/input/datepicker/datePickerJava8">
                                         <i class="pi pi-circle-on"></i>
                                         <span class="menuitem-text">DatePicker</span>
                                     </h:link>
                                 </li>
                                 <li>
-                                    <h:link outcome="/ui/input/calendar/calendar">
+                                    <h:link outcome="/ui/input/calendar/calendarJava8">
                                         <i class="pi pi-circle-on"></i>
                                         <span class="menuitem-text">Calendar</span>
                                     </h:link>

--- a/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -54,6 +54,7 @@
                 secondText: 'Sekunde',
                 currentText: 'Aktuelles Datum',
                 ampm: false,
+                ampm: false,
                 month: 'Monat',
                 week: 'Woche',
                 day: 'Tag',
@@ -174,7 +175,7 @@
                             <p:datePicker id="time4" value="#{calendarJava8View.dateTime4}" showTime="true" mindate="#{calendarJava8View.minDateTime}" maxdate="#{calendarJava8View.maxDateTime}" timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
                             <p:outputLabel for="time5" value="Time (with seconds):" />
-                            <p:datePicker id="time5" value="#{calendarJava8View.dateTime5}" showTime="true" showSeconds="true"/>
+                            <p:datePicker id="time5" value="#{calendarJava8View.dateTime5}" showTime="true" showSeconds="true" timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
                             <p:outputLabel for="timeDe" value="Time (German):" />
                             <p:datePicker id="timeDe" value="#{calendarJava8View.dateTimeDe}" showTime="true" locale="de" pattern="dd.MM.yyyy"  timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>

--- a/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -1,4 +1,4 @@
-<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+    <ui:composition xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:ui="http://java.sun.com/jsf/facelets"
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:f="http://java.sun.com/jsf/core"
@@ -89,113 +89,149 @@
     <ui:define name="implementation">
 
         <h:form id="form">
-            <p:growl id="msgs" showDetail="true" skipDetailIfEqualsSummary="true" />
+            <p:growl id="msgs" showDetail="true" skipDetailIfEqualsSummary="true">
+                <p:autoUpdate />
+            </p:growl>
 
-            <h:panelGrid columns="2" cellpadding="5">
-                <p:outputLabel for="inline" value="Inline:" />
-                <p:datePicker id="inline" value="#{calendarJava8View.date1}" inline="true" />
+            <p:outputPanel styleClass="p-grid">
+                <div class="p-col-12 p-md-8">
+                    <p:panel header="Date only" toggleable="true">
+                        <p:panelGrid columns="2" layout="flex" id="inputPanelDate" styleClass="ui-noborder" columnClasses="p-col-12 p-lg-4, p-col-12 p-lg-8">
+                            <p:outputLabel for="inline" value="Inline:" />
+                            <p:datePicker id="inline" value="#{calendarJava8View.date1}" inline="true" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="popup" value="Popup:" />
-                <p:datePicker id="popup" value="#{calendarJava8View.date2}" />
+                            <p:outputLabel for="popup" value="Popup:" />
+                            <p:datePicker id="popup" value="#{calendarJava8View.date2}" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="popupConvertDateTime" value="Popup (f:convertDateTime):" />
-                <p:datePicker id="popupConvertDateTime" value="#{calendarJava8View.date13}" pattern="MM/dd/yyyy">
-                    <f:convertDateTime pattern="MM/dd/yyyy" type="localDate" />
-                </p:datePicker>
+                            <p:outputLabel for="popupConvertDateTime" value="Popup (f:convertDateTime):" />
+                            <p:datePicker id="popupConvertDateTime" value="#{calendarJava8View.date13}" pattern="MM/dd/yyyy" showOtherMonths="#{calendarJava8View.showOtherMonths}">
+                                <f:convertDateTime pattern="MM/dd/yyyy" type="localDate" />
+                            </p:datePicker>
 
-                <p:outputLabel for="multiselect" value="Multiple Selection:" />
-                <p:datePicker id="multiselect" selectionMode="multiple" value="#{calendarJava8View.multi}" readonlyInput="true" />
+                            <p:outputLabel for="multiselect" value="Multiple Selection:" />
+                            <p:datePicker id="multiselect" selectionMode="multiple" value="#{calendarJava8View.multi}" readonlyInput="true" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="range" value="Range Selection:" />
-                <p:datePicker id="range" selectionMode="range" value="#{calendarJava8View.range}" readonlyInput="true" />
+                            <p:outputLabel for="range" value="Range Selection:" />
+                            <p:datePicker id="range" selectionMode="range" value="#{calendarJava8View.range}" readonlyInput="true" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="month" value="Month Picker:" />
-                <p:datePicker id="month" view="month" value="#{calendarJava8View.date3}" pattern="MM/yyyy" yearNavigator="true" yearRange="2000:2030" />
+                            <p:outputLabel for="month" value="Month Picker:" />
+                            <p:datePicker id="month" view="month" value="#{calendarJava8View.date3}" pattern="MM/yyyy" yearNavigator="true" yearRange="2000:2030" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="yearMonth" value="Month Picker (java.time.YearMonth):" />
-                <p:datePicker id="yearMonth" view="month" value="#{calendarJava8View.yearMonth}" pattern="MM/yyyy" yearNavigator="true" yearRange="2000:2030" />
+                            <p:outputLabel for="yearMonth" value="Month Picker (java.time.YearMonth):" />
+                            <p:datePicker id="yearMonth" view="month" value="#{calendarJava8View.yearMonth}" pattern="MM/yyyy" yearNavigator="true" yearRange="2000:2030" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="touch" value="Touch UI:" />
-                <p:datePicker id="touch" value="#{calendarJava8View.date4}" touchUI="true" showOtherMonths="true"/>
+                            <p:outputLabel for="touch" value="Touch UI:" />
+                            <p:datePicker id="touch" value="#{calendarJava8View.date4}" touchUI="true"  showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="dateTemplate" value="Date Template:" />
-                <p:datePicker id="dateTemplate" value="#{calendarJava8View.date5}" dateTemplate="dateTemplateFunc" />
+                            <p:outputLabel for="dateTemplate" value="Date Template:" />
+                            <p:datePicker id="dateTemplate" value="#{calendarJava8View.date5}" dateTemplate="dateTemplateFunc" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="disabledDD" value="Disabled Date/Day:" />
-                <p:datePicker id="disabledDD" value="#{calendarJava8View.date6}" disabledDays="#{calendarJava8View.invalidDays}" disabledDates="#{calendarJava8View.invalidDates}" readonlyInput="true" />
-                
-                <p:outputLabel for="button" value="Button:" />
-                <p:datePicker id="button" value="#{calendarJava8View.date7}" showIcon="true" />
+                            <p:outputLabel for="disabledDD" value="Disabled Date/Day:" />
+                            <p:datePicker id="disabledDD" value="#{calendarJava8View.date6}" disabledDays="#{calendarJava8View.invalidDays}" disabledDates="#{calendarJava8View.invalidDates}" readonlyInput="true" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="event" value="Select Event:" />
-                <p:datePicker id="event" value="#{calendarJava8View.date8}">
-                    <p:ajax event="dateSelect" listener="#{calendarJava8View.onDateSelect}" update="msgs" />
-                </p:datePicker>
+                            <p:outputLabel for="button" value="Button:" />
+                            <p:datePicker id="button" value="#{calendarJava8View.date7}" showIcon="true" showOtherMonths="#{calendarJava8View.showOtherMonths}" />
 
-                <p:outputLabel for="spanish" value="Spanish:" />
-                <p:datePicker id="spanish" value="#{calendarJava8View.date9}" locale="es" monthNavigator="true" pattern="yyyy-MMM-dd"/>
+                            <p:outputLabel for="event" value="Select Event:" />
+                            <p:datePicker id="event" value="#{calendarJava8View.date8}" showOtherMonths="#{calendarJava8View.showOtherMonths}">
+                                <p:ajax event="dateSelect" listener="#{calendarJava8View.onDateSelect}" update="msgs" />
+                            </p:datePicker>
 
-                <p:outputLabel for="german" value="German:" />
-                <p:outputPanel>
-                    <p:datePicker id="german" widgetVar="german" value="#{calendarJava8View.dateDe}" locale="de" monthNavigator="true" pattern="dd.MM.yyyy"/>
-                    <h:outputText value=" " />
-                    <p:commandButton type="button" value="Client Side API: setDate (24.12.2019)" onclick="PF('german').setDate('24.12.2019')" />
-                    <p:commandButton type="button" value="Client Side API: getDate" onclick="alert(PF('german').getDate())" />
-                </p:outputPanel>
+                            <p:outputLabel for="spanish" value="Spanish:" />
+                            <p:datePicker id="spanish" value="#{calendarJava8View.date9}" locale="es" monthNavigator="true" pattern="yyyy-MMM-dd" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="buttonbar" value="Button Bar:" />
-                <p:datePicker id="buttonbar" value="#{calendarJava8View.date10}" showButtonBar="true"/>
-                
-                <p:outputLabel for="minmax" value="Min-Max:" />
-                <p:datePicker id="minmax" value="#{calendarJava8View.date11}" mindate="#{calendarJava8View.minDate}" maxdate="#{calendarJava8View.maxDate}" readonlyInput="true"/>
+                            <p:outputLabel for="german" value="German:" />
+                            <p:outputPanel>
+                                <p:datePicker id="german" widgetVar="german" value="#{calendarJava8View.dateDe}" locale="de" monthNavigator="true" pattern="dd.MM.yyyy" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
+                                <h:outputText value=" " />
+                                <br/>
+                                <p:commandButton type="button" value="Client Side API: setDate (24.12.2019)" onclick="PF('german').setDate('24.12.2019')" />
+                                <p:commandButton type="button" value="Client Side API: getDate" onclick="alert(PF('german').getDate())" />
+                            </p:outputPanel>
 
-                <p:outputLabel for="multi" value="Multiple Months:" />
-                <p:datePicker id="multi" value="#{calendarJava8View.date12}" numberOfMonths="3"/>
+                            <p:outputLabel for="buttonbar" value="Button Bar:" />
+                            <p:datePicker id="buttonbar" value="#{calendarJava8View.date10}" showButtonBar="true" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="time1" value="Time:" />
-                <p:datePicker id="time1" value="#{calendarJava8View.dateTime1}" showTime="true"/>
+                            <p:outputLabel for="minmax" value="Min-Max:" />
+                            <p:datePicker id="minmax" value="#{calendarJava8View.date11}" mindate="#{calendarJava8View.minDate}" maxdate="#{calendarJava8View.maxDate}" readonlyInput="true" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="time3" value="Time (Min-Max):" />
-                <p:datePicker id="time3" value="#{calendarJava8View.dateTime3}" showTime="true" mindate="#{calendarJava8View.minDateTime}" maxdate="#{calendarJava8View.maxDateTime}"/>
+                            <p:outputLabel for="multi" value="Multiple Months:" />
+                            <p:datePicker id="multi" value="#{calendarJava8View.date12}" numberOfMonths="3" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
+                        </p:panelGrid>
+                    </p:panel>
 
-                <p:outputLabel for="time4" value="Time (Min-Max; preset value):" />
-                <p:datePicker id="time4" value="#{calendarJava8View.dateTime4}" showTime="true" mindate="#{calendarJava8View.minDateTime}" maxdate="#{calendarJava8View.maxDateTime}"/>
+                    <br/>
 
-                <p:outputLabel for="time5" value="Time (with seconds):" />
-                <p:datePicker id="time5" value="#{calendarJava8View.dateTime5}" showTime="true" showSeconds="true"/>
+                    <p:panel header="Date+Time (showTime=true)" toggleable="true">
+                        <p:panelGrid columns="2" layout="flex" id="inputPanelDateTime" styleClass="ui-noborder" columnClasses="p-col-12 p-lg-4, p-col-12 p-lg-8">
+                            <p:outputLabel for="time1" value="Time:" />
+                            <p:datePicker id="time1" value="#{calendarJava8View.dateTime1}" showTime="true" timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="timeDe" value="Time (German):" />
-                <p:datePicker id="timeDe" value="#{calendarJava8View.dateTimeDe}" showTime="true" locale="de" pattern="dd.MM.yyyy" />
+                            <p:outputLabel for="time3" value="Time (Min-Max):" />
+                            <p:datePicker id="time3" value="#{calendarJava8View.dateTime3}" showTime="true" mindate="#{calendarJava8View.minDateTime}" maxdate="#{calendarJava8View.maxDateTime}" timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="time2" value="Time (Timezone GMT+8):" />
-                <p:datePicker id="time2" value="#{calendarJava8View.dateTime2}" showTime="true" timeZone="GMT+8"/>
+                            <p:outputLabel for="time4" value="Time (Min-Max; preset value):" />
+                            <p:datePicker id="time4" value="#{calendarJava8View.dateTime4}" showTime="true" mindate="#{calendarJava8View.minDateTime}" maxdate="#{calendarJava8View.maxDateTime}" timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="zonedDateTime1" value="Time (ZonedDateTime; not supported yet):" />
-                <p:datePicker id="zonedDateTime1" value="#{calendarJava8View.zonedDateTime1}" showTime="true"/>
+                            <p:outputLabel for="time5" value="Time (with seconds):" />
+                            <p:datePicker id="time5" value="#{calendarJava8View.dateTime5}" showTime="true" showSeconds="true"/>
 
-                <p:outputLabel for="timeonly" value="Time Only (HH:mm):" />
-                <p:datePicker id="timeonly" value="#{calendarJava8View.time1}" timeOnly="true" pattern="HH:mm"/>
+                            <p:outputLabel for="timeDe" value="Time (German):" />
+                            <p:datePicker id="timeDe" value="#{calendarJava8View.dateTimeDe}" showTime="true" locale="de" pattern="dd.MM.yyyy"  timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="timeonlyMinMax" value="Time Only (Min-Max):" />
-                <p:outputPanel>
-                    <p:datePicker id="timeonlyMinMax" value="#{calendarJava8View.time3}" timeOnly="true" mindate="#{calendarJava8View.minTime}" maxdate="#{calendarJava8View.maxTime}"/>
-                    (between <h:outputText value="#{calendarJava8View.minTime}"></h:outputText> and <h:outputText value="#{calendarJava8View.maxTime}"></h:outputText>)
-                </p:outputPanel>
+                            <p:outputLabel for="time2" value="Time (Timezone GMT+8):" />
+                            <p:datePicker id="time2" value="#{calendarJava8View.dateTime2}" showTime="true" timeZone="GMT+8" timeInput="#{calendarJava8View.timeInput}" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
 
-                <p:outputLabel for="timeonlyMinMax2" value="Time Only (Min-Max; preset value):" />
-                <p:outputPanel>
-                    <p:datePicker id="timeonlyMinMax2" value="#{calendarJava8View.time4}" timeOnly="true" mindate="#{calendarJava8View.minTime}" maxdate="#{calendarJava8View.maxTime}" />
-                    (between <h:outputText value="#{calendarJava8View.minTime}"></h:outputText> and <h:outputText value="#{calendarJava8View.maxTime}"></h:outputText>)
-                </p:outputPanel>
+                            <p:outputLabel for="zonedDateTime1" value="Time (ZonedDateTime; not supported yet):" />
+                            <p:datePicker id="zonedDateTime1" value="#{calendarJava8View.zonedDateTime1}" showTime="true" showOtherMonths="#{calendarJava8View.showOtherMonths}"/>
+                        </p:panelGrid>
+                    </p:panel>
 
-                <p:outputLabel for="timeonlySeconds" value="Time Only (HH:mm:ss):" />
-                <p:datePicker id="timeonlySeconds" value="#{calendarJava8View.time5}" timeOnly="true" showSeconds="true" pattern="HH:mm:ss"/>
+                    <br/>
 
-                <p:outputLabel for="timeonly12" value="Time Only (AM/PM):" />
-                <p:datePicker id="timeonly12" value="#{calendarJava8View.time6}" timeOnly="true" hourFormat="12" pattern="HH:mm"/>
-            </h:panelGrid>
+                    <p:panel header="Time only (timeOnly=true)" toggleable="true">
+                        <p:panelGrid columns="2" layout="flex" id="inputPanelTime" styleClass="ui-noborder" columnClasses="p-col-12 p-lg-4, p-col-12 p-lg-8">
+                            <p:outputLabel for="timeonly" value="Time Only (HH:mm):" />
+                            <p:datePicker id="timeonly" value="#{calendarJava8View.time1}" timeOnly="true" pattern="HH:mm" timeInput="#{calendarJava8View.timeInput}"/>
 
-            <p:commandButton value="Submit" update="msgs" action="#{calendarJava8View.click}" icon="pi pi-check" />
+                            <p:outputLabel for="timeonlyMinMax" value="Time Only (Min-Max):" />
+                            <p:outputPanel>
+                                <p:datePicker id="timeonlyMinMax" value="#{calendarJava8View.time3}" timeOnly="true" mindate="#{calendarJava8View.minTime}" maxdate="#{calendarJava8View.maxTime}" timeInput="#{calendarJava8View.timeInput}"/>
+                                (between <h:outputText value="#{calendarJava8View.minTime}"></h:outputText> and <h:outputText value="#{calendarJava8View.maxTime}"></h:outputText>)
+                            </p:outputPanel>
+
+                            <p:outputLabel for="timeonlyMinMax2" value="Time Only (Min-Max; preset value):" />
+                            <p:outputPanel>
+                                <p:datePicker id="timeonlyMinMax2" value="#{calendarJava8View.time4}" timeOnly="true" mindate="#{calendarJava8View.minTime}" maxdate="#{calendarJava8View.maxTime}" timeInput="#{calendarJava8View.timeInput}" />
+                                (between <h:outputText value="#{calendarJava8View.minTime}"></h:outputText> and <h:outputText value="#{calendarJava8View.maxTime}"></h:outputText>)
+                            </p:outputPanel>
+
+                            <p:outputLabel for="timeonlySeconds" value="Time Only (HH:mm:ss):" />
+                            <p:datePicker id="timeonlySeconds" value="#{calendarJava8View.time5}" timeOnly="true" showSeconds="true" pattern="HH:mm:ss" timeInput="#{calendarJava8View.timeInput}"/>
+
+                            <p:outputLabel for="timeonly12" value="Time Only (AM/PM):" />
+                            <p:datePicker id="timeonly12" value="#{calendarJava8View.time6}" timeOnly="true" hourFormat="12" pattern="HH:mm" timeInput="#{calendarJava8View.timeInput}"/>
+                        </p:panelGrid>
+                    </p:panel>
+
+                    <br/>
+
+                    <p:commandButton value="Submit" update="form" action="#{calendarJava8View.click}" icon="pi pi-check" />
+                </div>
+                <div class="p-col-12 p-md-4">
+                    <p:panel header="Configuration">
+                        <p:panelGrid columns="1" layout="flex" styleClass="ui-noborder">
+                            <p:selectBooleanCheckbox value="#{calendarJava8View.timeInput}" itemLabel="timeInput">
+                                <p:ajax update="inputPanelDate,inputPanelDateTime,inputPanelTime" process="form" />
+                            </p:selectBooleanCheckbox>
+
+                            <p:selectBooleanCheckbox value="#{calendarJava8View.showOtherMonths}" itemLabel="showOtherMonths">
+                                <p:ajax update="inputPanelDate,inputPanelDateTime,inputPanelTime" process="form" />
+                            </p:selectBooleanCheckbox>
+                        </p:panelGrid>
+                    </p:panel>
+                </div>
+            </p:outputPanel>
 
             <p:dialog modal="true" resizable="false" header="Values" widgetVar="dlg" showEffect="fold">
                 <p:panelGrid id="display" columns="4" columnClasses="label,value,label,value">


### PR DESCRIPTION
and ...
- move pom.xml from 8.0 to 9.0
- default from menu.xhtml to the Java8-xhtml´s for DatePicker and Calendar

@tandraschko, @melloware: I did a new PR because this was the easier way. I´ll close the old one.