### PR TITLE
PR-5831: tooltips/titles on fileupload component

### DIFF
--- a/src/main/webapp/ui/file/upload/template.xhtml
+++ b/src/main/webapp/ui/file/upload/template.xhtml
@@ -24,6 +24,9 @@
                 <li>
                     <a href="#{request.contextPath}/ui/file/upload/chunked.xhtml">&bull; Chunked</a>
                 </li>
+                <li>
+                    <a href="#{request.contextPath}/ui/file/upload/tooltips.xhtml">&bull; Tooltips</a>
+                </li>
             </ul>
         </div>
     </ui:define>

--- a/src/main/webapp/ui/file/upload/tooltips.xhtml
+++ b/src/main/webapp/ui/file/upload/tooltips.xhtml
@@ -1,0 +1,65 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:p="http://primefaces.org/ui"
+                template="./template.xhtml">
+
+    <ui:define name="title">
+        FileUpload - <span class="subitem">Tooltips</span>
+    </ui:define>
+
+    <ui:define name="description">
+        Tooltips can be attached to each one of FileUpload buttons in advanced mode using 
+        <p:link href="https://primefaces.github.io/primefaces/9_0/#/core/searchexpression?id=primefaces-selectors-pfs">PrimeFaces Selectors</p:link>.
+        Moreover, you can use plain html browser native titles as well.
+    </ui:define>
+
+    <ui:param name="documentationLink" value="/components/fileupload" />
+    <ui:param name="widgetLink" value="fileupload" />
+
+	<ui:define name="implementation">
+
+		<h:form id="formId">
+
+			<p:fileUpload id="uploader1" mode="advanced" />
+
+			<p:outputPanel id="tooltipsPanel">
+
+				<p:tooltip id="uploaderChooseFileBeforeUploadToolTip"
+					widgetVar="chooseWV" position="top"
+					for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-choose)"
+					value="Choose button tooltip" />
+
+				<p:tooltip id="uploaderUploadButtonToolTip" position="right"
+					for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-upload)"
+					value="Upload button tooltip" showEffect="clip" hideEffect="explode"/>
+
+				<p:tooltip id="uploaderCancelButtonToolTip" position="bottom"
+					for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-cancel)"
+					value="Cancel button tooltip" />
+
+			</p:outputPanel>
+			
+			<br/>
+
+			<p:fileUpload id="uploader2" mode="advanced"
+				chooseButtonTitle="Choose button tooltip"
+				uploadButtonTitle="Upload button tooltip"
+				cancelButtonTitle="Cancel button tooltip"
+			/>
+			
+			<br/>
+
+			<p:fileUpload id="uploader3" mode="simple" skinSimple="true" title="my custom title"/>
+			
+			<br/>
+			<br/>
+
+			<p:fileUpload id="uploader4" mode="simple" title="my custom title"/>
+
+		</h:form>
+
+	</ui:define>
+
+</ui:composition>

--- a/src/main/webapp/ui/file/upload/tooltips.xhtml
+++ b/src/main/webapp/ui/file/upload/tooltips.xhtml
@@ -22,43 +22,46 @@
 
 		<h:form id="formId">
 
-			<p:fileUpload id="uploader1" mode="advanced" />
+            <p:fileUpload id="uploader1" mode="advanced" />
 
-			<p:outputPanel id="tooltipsPanel">
+            <p:outputPanel id="tooltipsPanel">
 
-				<p:tooltip id="uploaderChooseFileBeforeUploadToolTip"
-					widgetVar="chooseWV" position="top"
-					for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-choose)"
-					value="Choose button tooltip" />
+                <p:tooltip id="uploaderChooseFileBeforeUploadToolTip"
+                    widgetVar="chooseWV" position="top"
+                    for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-choose)"
+                    value="Choose button tooltip" />
 
-				<p:tooltip id="uploaderUploadButtonToolTip" position="right"
-					for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-upload)"
-					value="Upload button tooltip" showEffect="clip" hideEffect="explode"/>
+                <p:tooltip id="uploaderUploadButtonToolTip"
+                    position="right"
+                    for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-upload)"
+                    value="Upload button tooltip" showEffect="clip"
+                    hideEffect="explode" />
 
-				<p:tooltip id="uploaderCancelButtonToolTip" position="bottom"
-					for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-cancel)"
-					value="Cancel button tooltip" />
+                <p:tooltip id="uploaderCancelButtonToolTip"
+                    position="bottom"
+                    for="@(#formId\:uploader1 > .ui-fileupload-buttonbar > .ui-fileupload-cancel)"
+                    value="Cancel button tooltip" />
 
-			</p:outputPanel>
-			
-			<br/>
+            </p:outputPanel>
 
-			<p:fileUpload id="uploader2" mode="advanced"
-				chooseButtonTitle="Choose button tooltip"
-				uploadButtonTitle="Upload button tooltip"
-				cancelButtonTitle="Cancel button tooltip"
-			/>
-			
-			<br/>
+            <br />
 
-			<p:fileUpload id="uploader3" mode="simple" skinSimple="true" title="my custom title"/>
-			
-			<br/>
-			<br/>
+            <p:fileUpload id="uploader2" mode="advanced"
+                chooseButtonTitle="Choose button tooltip"
+                uploadButtonTitle="Upload button tooltip"
+                cancelButtonTitle="Cancel button tooltip" />
+            <br />
 
-			<p:fileUpload id="uploader4" mode="simple" title="my custom title"/>
+            <p:fileUpload id="uploader3" mode="simple" skinSimple="true"
+                title="my custom title" />
 
-		</h:form>
+            <br />
+            <br />
+
+            <p:fileUpload id="uploader4" mode="simple"
+                title="my custom title" />
+
+        </h:form>
 
 	</ui:define>
 


### PR DESCRIPTION
This PR is a consequence of the fix of issue https://github.com/primefaces/primefaces/issues/5831. Here, a new page is included showing the usage of:
- new `title`, `chooseButtonTitle`, `uploadButtonTitle` & `cancelButtonTitle` attributes for `FileUpload` component
- `p:tooltip`'s attached to `FileUpload` buttons

You can be also interested in check PR https://github.com/primefaces/primefaces/pull/5954