### PR TITLE
PR-12: allow Dynamic content support in ImageCropper - usage example

### DIFF
--- a/src/main/java/org/primefaces/showcase/view/multimedia/DynamicCropper.java
+++ b/src/main/java/org/primefaces/showcase/view/multimedia/DynamicCropper.java
@@ -37,7 +37,7 @@ public class DynamicCropper implements Serializable {
     
     @PostConstruct
     public void init() {
-        this.numberOfIterations = 10;
+        this.numberOfIterations = 5;
         try {
             this.image = mandelbrotSet(width, height, numberOfIterations);
         } catch (IOException e) {

--- a/src/main/java/org/primefaces/showcase/view/multimedia/DynamicCropper.java
+++ b/src/main/java/org/primefaces/showcase/view/multimedia/DynamicCropper.java
@@ -1,0 +1,167 @@
+package org.primefaces.showcase.view.multimedia;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.SessionScoped;
+import javax.faces.application.FacesMessage;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+import javax.faces.event.PhaseId;
+import javax.faces.event.ValueChangeEvent;
+import javax.imageio.ImageIO;
+import javax.imageio.stream.FileImageOutputStream;
+import javax.inject.Named;
+
+import org.primefaces.model.CroppedImage;
+import org.primefaces.model.DefaultStreamedContent;
+import org.primefaces.model.StreamedContent;
+
+@Named
+@SessionScoped
+public class DynamicCropper implements Serializable {
+    
+    private BufferedImage image;
+    private final int width = 500;
+    private final int height = 350;
+    private int numberOfIterations;
+    
+    @PostConstruct
+    public void init() {
+        this.numberOfIterations = 10;
+        try {
+            this.image = mandelbrotSet(width, height, numberOfIterations);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    public StreamedContent getImage() {
+        
+        FacesContext context = FacesContext.getCurrentInstance();
+
+        StreamedContent result = null;
+        if (context.getCurrentPhaseId() == PhaseId.RENDER_RESPONSE) {
+            result = new DefaultStreamedContent();
+        }
+        else {
+            result = DefaultStreamedContent.builder().contentType("image/png").stream(() -> {
+                try {
+                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                    ImageIO.write(this.image, "png", outputStream);
+                    return new ByteArrayInputStream(outputStream.toByteArray());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return null;
+                }
+            }).build();
+        }
+        
+        return result;
+    }
+    
+    public int getNumberOfIterations() {
+        return numberOfIterations;
+    }
+    
+    public void setNumberOfIterations(int numberOfIterations) {
+        this.numberOfIterations = numberOfIterations;
+    }
+    
+    public void updateImage(ValueChangeEvent event) {
+        Number newValue = (Number) event.getNewValue();
+        try {
+            this.image = this.mandelbrotSet(width, height, newValue.intValue());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    } 
+     
+    private CroppedImage croppedImage;
+     
+    private String newImageName;
+ 
+    public CroppedImage getCroppedImage() {
+        return croppedImage;
+    }
+ 
+    public void setCroppedImage(CroppedImage croppedImage) {
+        this.croppedImage = croppedImage;
+    }
+    
+    public void crop() {
+        
+        if(this.croppedImage != null) {
+            String imageName = UUID.randomUUID().toString() + ".png";
+            setNewImageName(imageName);
+            ExternalContext externalContext = FacesContext.getCurrentInstance().getExternalContext();
+            
+            Path path = Paths.get(externalContext.getRealPath(""), "resources", "demo", "images", "crop", imageName);
+             
+            FileImageOutputStream imageOutput;
+            try {
+                imageOutput = new FileImageOutputStream(path.toFile());
+                imageOutput.write(croppedImage.getBytes(), 0, croppedImage.getBytes().length);
+                imageOutput.close();
+                FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_INFO, "Success", "Cropping finished."));
+            } catch (Exception e) {
+                FacesContext.getCurrentInstance().addMessage(null, new FacesMessage(FacesMessage.SEVERITY_ERROR, "Error", "Cropping failed."));
+            }
+        }
+        
+    }
+     
+    public String getNewImageName() {
+        return newImageName;
+    }
+ 
+    public void setNewImageName(String newImageName) {
+        this.newImageName = newImageName;
+    }
+    
+    private BufferedImage mandelbrotSet(int width, int height, int maxIterations) throws IOException {
+        
+        BufferedImage result = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        
+        final int[] colorBuffer = new int[maxIterations];
+        Arrays.setAll(colorBuffer, i -> {
+            float h = i / 256.0f;
+            float b = i / (i + 8.0f);
+            return Color.HSBtoRGB(h, 1, b);
+        });
+
+        final int widthBy2 = width / 2;
+        final int heightBy2 = height / 2;
+        for (int i = 0; i < height; ++i) {
+            for (int j = 0; j < width; ++j) {
+                final double re = (j - widthBy2) * 4.0 / width;
+                final double im = (i - heightBy2) * 4.0 / width;
+                double x = .0, y = .0, rsq = .0;
+                int iteration = 0;
+                for (; rsq < 4 && iteration < maxIterations; ++iteration) {
+                    double newX = x*x - y*y + re;
+                    y = 2*x*y + im;
+                    x = newX;
+                    rsq = x*x + y*y;
+                } 
+                if (iteration < maxIterations) {
+                    result.setRGB(j, i, colorBuffer[iteration]);
+                }
+                else {
+                    result.setRGB(j, i, 0);
+                }
+            }
+        }
+        return result;
+    }
+    
+}

--- a/src/main/webapp/WEB-INF/menu.xhtml
+++ b/src/main/webapp/WEB-INF/menu.xhtml
@@ -1010,7 +1010,7 @@
                                     </h:link>
                                 </li>
                                 <li>
-                                    <h:link outcome="/ui/multimedia/cropper">
+                                    <h:link outcome="/ui/multimedia/cropper/cropper">
                                         <i class="pi pi-circle-on"></i>
                                         <span class="menuitem-text">Cropper</span>
                                     </h:link>

--- a/src/main/webapp/ui/multimedia/cropper/cropper.xhtml
+++ b/src/main/webapp/ui/multimedia/cropper/cropper.xhtml
@@ -3,7 +3,7 @@
                 xmlns:h="http://java.sun.com/jsf/html"
                 xmlns:f="http://java.sun.com/jsf/core"
                 xmlns:p="http://primefaces.org/ui"
-                template="/WEB-INF/template.xhtml">
+                template="template.xhtml">
 
     <ui:define name="title">
         ImageCropper

--- a/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
+++ b/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
@@ -20,38 +20,44 @@
         
         <h:form>
 	
-			<p:growl id="msgs" showDetail="true"/>
-        
+            <p:growl id="msgs" showDetail="true"/>
+
             <h:panelGrid columns="3">
-        
-	        	
-	        	
-            	<h:panelGrid columns="1">
-            	
-            		<p:spinner id="iterationSpinner" value="#{dynamicCropper.numberOfIterations}" min="5" max="50" stepFactor="5"
-		        		valueChangeListener="#{dynamicCropper.updateImage}">
-		        		<p:ajax process="@this" update="cropper" />
-		        	</p:spinner>
-		        	
-            		<h:panelGrid columns="2">
-			        	<p:outputPanel id="cropper">
-				        	<p:imageCropper value="#{dynamicCropper.croppedImage}" id="streamed_cropper" cache="false"
-				        		stream="#{dynamicCropper.image}" 
-				        		initialCoords="50,50,150,100" minSize="50,50" maxSize="350,350"/>
-			        	</p:outputPanel>
-			        	<p:outputPanel id="cropped">
-				            <p:graphicImage rendered="#{not empty dynamicCropper.newImageName}" 
-				            	name="demo/images/crop/#{dynamicCropper.newImageName}" />
-				        </p:outputPanel>
-				    </h:panelGrid>
-	        		
-       				<p:commandButton value="Crop" action="#{dynamicCropper.crop}" 
-       					update="cropped msgs" icon="pi pi-clone"/>
-       				
-	        	</h:panelGrid>
-	        	
-		    </h:panelGrid>
-		    
+
+
+                <h:panelGrid columns="1">
+
+                    <p:spinner id="iterationSpinner"
+                        value="#{dynamicCropper.numberOfIterations}"
+                        min="5" max="50" stepFactor="5"
+                        valueChangeListener="#{dynamicCropper.updateImage}">
+                        <p:ajax process="@this" update="cropper" />
+                    </p:spinner>
+
+                    <h:panelGrid columns="2">
+                        <p:outputPanel id="cropper">
+                            <p:imageCropper
+                                value="#{dynamicCropper.croppedImage}"
+                                id="streamed_cropper" cache="false"
+                                stream="#{dynamicCropper.image}"
+                                initialCoords="50,50,150,100"
+                                minSize="50,50" maxSize="350,350" />
+                        </p:outputPanel>
+                        <p:outputPanel id="cropped">
+                            <p:graphicImage
+                                rendered="#{not empty dynamicCropper.newImageName}"
+                                name="demo/images/crop/#{dynamicCropper.newImageName}" />
+                        </p:outputPanel>
+                    </h:panelGrid>
+
+                    <p:commandButton value="Crop"
+                        action="#{dynamicCropper.crop}"
+                        update="cropped msgs" icon="pi pi-clone" />
+
+                </h:panelGrid>
+
+            </h:panelGrid>
+
         </h:form>
         
     </ui:define>

--- a/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
+++ b/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
@@ -1,0 +1,59 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:p="http://primefaces.org/ui"
+                template="template.xhtml">
+
+    <ui:define name="title">
+        ImageCropper
+    </ui:define>
+
+    <ui:define name="description">
+        ImageCropper can load the image dynamically using StreamedContent.
+    </ui:define>
+
+    <ui:param name="documentationLink" value="/components/imagecropper" />
+    <ui:param name="widgetLink" value="imagecropper" />
+
+    <ui:define name="implementation">
+        
+        <h:form>
+	
+			<p:growl id="msgs" showDetail="true"/>
+        
+            <h:panelGrid columns="3">
+        
+	        	
+	        	
+            	<h:panelGrid columns="1">
+            	
+            		<p:spinner id="iterationSpinner" value="#{dynamicCropper.numberOfIterations}" min="5" max="50" stepFactor="5"
+		        		valueChangeListener="#{dynamicCropper.updateImage}">
+		        		<p:ajax process="@this" update="cropper" />
+		        	</p:spinner>
+		        	
+            		<h:panelGrid columns="2">
+			        	<p:outputPanel id="cropper">
+				        	<p:imageCropper value="#{dynamicCropper.croppedImage}" id="streamed_cropper" cache="false"
+				        		stream="#{dynamicCropper.image}" 
+				        		initialCoords="50,50,150,100" minSize="50,50" maxSize="350,350"/>
+			        	</p:outputPanel>
+			        	<p:outputPanel id="cropped">
+				            <p:graphicImage rendered="#{not empty dynamicCropper.newImageName}" 
+				            	name="demo/images/crop/#{dynamicCropper.newImageName}" />
+				        </p:outputPanel>
+				    </h:panelGrid>
+	        		
+       				<p:commandButton value="Crop" action="#{dynamicCropper.crop}" 
+       					update="cropped msgs" icon="pi pi-clone"/>
+       				
+	        	</h:panelGrid>
+	        	
+		    </h:panelGrid>
+		    
+        </h:form>
+        
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
+++ b/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
@@ -24,7 +24,6 @@
 
             <h:panelGrid columns="3">
 
-
                 <h:panelGrid columns="1">
 
                     <p:spinner id="iterationSpinner"

--- a/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
+++ b/src/main/webapp/ui/multimedia/cropper/dynamic.xhtml
@@ -38,7 +38,7 @@
                             <p:imageCropper
                                 value="#{dynamicCropper.croppedImage}"
                                 id="streamed_cropper" cache="false"
-                                stream="#{dynamicCropper.image}"
+                                image="#{dynamicCropper.image}"
                                 initialCoords="50,50,150,100"
                                 minSize="50,50" maxSize="350,350" />
                         </p:outputPanel>

--- a/src/main/webapp/ui/multimedia/cropper/template.xhtml
+++ b/src/main/webapp/ui/multimedia/cropper/template.xhtml
@@ -1,0 +1,19 @@
+<!DOCTYPE html [
+    <!ENTITY bull "&#8226;"> ]>
+<ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:ui="http://java.sun.com/jsf/facelets" xmlns:h="http://java.sun.com/jsf/html"
+    xmlns:f="http://java.sun.com/jsf/core" xmlns:p="http://primefaces.org/ui" template="/WEB-INF/template.xhtml">
+
+    <ui:define name="submenu">
+        <div>
+            <ul>
+                <li>
+                    <a href="#{request.contextPath}/ui/multimedia/cropper/cropper.xhtml">&bull; Basic</a>
+                </li>
+                <li>
+                    <a href="#{request.contextPath}/ui/multimedia/cropper/dynamic.xhtml">&bull; Dynamic</a>
+                </li>
+            </ul>
+        </div>
+    </ui:define>
+
+</ui:composition>


### PR DESCRIPTION
This PR introduces the usage of `StreamedContent` in `ImageCropper` as asked in https://github.com/primefaces/primefaces/issues/12. Please refer to https://github.com/primefaces/primefaces/pull/5957 for more details.