### PR TITLE
FIX PrimeFaces PR-5182 - Add editInitEvent attribute to editable TreeTable

### DIFF
--- a/src/main/java/org/primefaces/showcase/view/data/treetable/EditView.java
+++ b/src/main/java/org/primefaces/showcase/view/data/treetable/EditView.java
@@ -36,6 +36,8 @@ public class EditView implements Serializable{
     
     private TreeNode root2;
     
+    private TreeNode root3;
+    
     @Inject
     private DocumentService service;
     
@@ -43,6 +45,7 @@ public class EditView implements Serializable{
     public void init() {
         root = service.createDocuments();
         root2 = service.createDocuments();
+        root3 = service.createDocuments();
     }
 
     public TreeNode getRoot() {
@@ -51,6 +54,10 @@ public class EditView implements Serializable{
 
     public TreeNode getRoot2() {
         return root2;
+    }
+    
+    public TreeNode getRoot3() {
+        return root3;
     }
     
     public void setService(DocumentService service) {

--- a/src/main/webapp/ui/data/datatable/editInitEvent.xhtml
+++ b/src/main/webapp/ui/data/datatable/editInitEvent.xhtml
@@ -1,0 +1,124 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:p="http://primefaces.org/ui"
+                template="./template.xhtml">
+    <ui:define name="head">
+        <style type="text/css">
+            .ui-row-editor .ui-row-editor-pencil {
+                margin-left:8px;
+            }
+        </style>
+    </ui:define>
+    
+    <ui:define name="title">
+        DataTable - <span class="subitem">editInitEvent</span>
+    </ui:define>
+
+    <ui:define name="description">
+        editInitEvent defines a client side event to open cell on editable table.
+    </ui:define>
+
+    <ui:param name="documentationLink" value="/components/datatable" />
+    <ui:param name="widgetLink" value="datatable" />
+
+    <ui:define name="implementation">
+
+         <h:form id="form">
+            <p:growl id="msgs" showDetail="true"/>
+
+            <p:dataTable id="cars1" var="car" value="#{dtEditView.cars1}" editable="true" editMode="cell" widgetVar="cellCars1" editInitEvent="mouseover">
+                <f:facet name="header">
+                    Cell Editing On Mouse Over Event (mouseover)
+                </f:facet>
+
+                <p:ajax event="cellEdit" listener="#{dtEditView.onCellEdit}" update=":form:msgs" />
+
+                <p:column headerText="Id">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.id}" /></f:facet>
+                        <f:facet name="input"><p:inputText id="modelInput" value="#{car.id}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+
+                <p:column headerText="Year">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.year}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{car.year}" style="width:100%" label="Year"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+
+                <p:column headerText="Brand">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.brand}" /></f:facet>
+                        <f:facet name="input">
+                            <h:selectOneMenu value="#{car.brand}" style="width:100%">
+                                <f:selectItems value="#{dtEditView.brands}" var="man" itemLabel="#{man}" itemValue="#{man}" />
+                            </h:selectOneMenu>
+                        </f:facet>
+                    </p:cellEditor>
+                </p:column>
+
+                <p:column headerText="Color">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.color}" /></f:facet>
+                        <f:facet name="input">
+                            <h:selectOneMenu value="#{car.color}" style="width:100%">
+                                <f:selectItems value="#{dtEditView.colors}" var="color" itemLabel="#{color}" itemValue="#{color}" />
+                            </h:selectOneMenu>
+                        </f:facet>
+                    </p:cellEditor>
+                </p:column>
+
+            </p:dataTable>
+
+            <p:dataTable id="cars2" var="car" value="#{dtEditView.cars2}" editable="true" editMode="cell" widgetVar="cellCars2" editInitEvent="dblclick">
+                <f:facet name="header">
+                    Cell Editing with Double Click Event (dblclick)
+                </f:facet>
+
+                <p:ajax event="cellEdit" listener="#{dtEditView.onCellEdit}" update=":form:msgs" />
+
+                <p:column headerText="Id">
+                       <p:cellEditor>
+                           <f:facet name="output"><h:outputText value="#{car.id}" /></f:facet>
+                           <f:facet name="input"><p:inputText id="modelInput" value="#{car.id}" style="width:96%"/></f:facet>
+                       </p:cellEditor>
+                   </p:column>
+
+                   <p:column headerText="Year">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.year}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{car.year}" style="width:96%" label="Year"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+
+                <p:column headerText="Brand">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.brand}" /></f:facet>
+                        <f:facet name="input">
+                            <h:selectOneMenu value="#{car.brand}" style="width:100%">
+                                <f:selectItems value="#{dtEditView.brands}" var="man" itemLabel="#{man}" itemValue="#{man}" />
+                            </h:selectOneMenu>
+                        </f:facet>
+                    </p:cellEditor>
+                </p:column>
+
+                <p:column headerText="Color">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{car.color}" /></f:facet>
+                        <f:facet name="input">
+                            <h:selectOneMenu value="#{car.color}" style="width:100%">
+                                <f:selectItems value="#{dtEditView.colors}" var="color" itemLabel="#{color}" itemValue="#{color}" />
+                            </h:selectOneMenu>
+                        </f:facet>
+                    </p:cellEditor>
+                </p:column>
+            </p:dataTable>
+            
+         </h:form>
+        
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/ui/data/datatable/editInitEvent.xhtml
+++ b/src/main/webapp/ui/data/datatable/editInitEvent.xhtml
@@ -28,7 +28,7 @@
          <h:form id="form">
             <p:growl id="msgs" showDetail="true"/>
 
-            <p:dataTable id="cars1" var="car" value="#{dtEditView.cars1}" editable="true" editMode="cell" widgetVar="cellCars1" editInitEvent="mouseover">
+            <p:dataTable id="cars1" var="car" value="#{dtEditView.cars1}" editable="true" editMode="cell" widgetVar="cellCars1" editInitEvent="mouseover" style="margin-bottom:20px">
                 <f:facet name="header">
                     Cell Editing On Mouse Over Event (mouseover)
                 </f:facet>

--- a/src/main/webapp/ui/data/datatable/template.xhtml
+++ b/src/main/webapp/ui/data/datatable/template.xhtml
@@ -81,6 +81,9 @@
                 <li>
                     <a href="#{request.contextPath}/ui/data/datatable/rowGroup.xhtml">&bull; RowGroup</a>
                 </li>
+                <li>
+                    <a href="#{request.contextPath}/ui/data/datatable/editInitEvent.xhtml">&bull; editInitEvent</a>
+                </li>
             </ul>
         </div>
     </ui:define>

--- a/src/main/webapp/ui/data/treetable/editInitEvent.xhtml
+++ b/src/main/webapp/ui/data/treetable/editInitEvent.xhtml
@@ -1,0 +1,124 @@
+<ui:composition xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:ui="http://java.sun.com/jsf/facelets"
+                xmlns:h="http://java.sun.com/jsf/html"
+                xmlns:f="http://java.sun.com/jsf/core"
+                xmlns:p="http://primefaces.org/ui"
+                template="./template.xhtml">
+    <ui:define name="head">
+        <style type="text/css">
+            .ui-row-editor .ui-row-editor-pencil {
+                margin-left:8px;
+            }
+
+            .ui-editable-column .ui-cell-editor-input {
+                overflow: hidden;
+            }
+
+            .ui-editable-column .ui-cell-editor-input * {
+                box-sizing: border-box;
+            }
+        </style>
+    </ui:define>
+    
+    <ui:define name="title">
+        TreeTable - <span class="subitem">editInitEvent</span>
+    </ui:define>
+
+    <ui:define name="description">
+        editInitEvent defines a client side event to open cell on editable treetable.
+    </ui:define>
+
+    <ui:param name="documentationLink" value="/components/treetable" />
+    <ui:param name="widgetLink" value="treetable" />
+
+    <ui:define name="implementation">
+
+         <h:form id="form">
+            <p:growl id="msgs" showDetail="true"/>
+
+            <p:treeTable value="#{ttEditView.root}" editable="true" editMode="cell" var="document" style="margin-bottom:20px" editInitEvent="click">
+                <f:facet name="header">
+                    Cell Editing On Click is the default behavior
+                </f:facet>
+                
+                <p:ajax event="cellEdit" listener="#{ttEditView.onCellEdit}" update=":form:msgs" />
+
+                <p:column headerText="Name"> 
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.name}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.name}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+                <p:column headerText="Size">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.size}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.size}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+                <p:column headerText="Type">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.type}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.type}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+            </p:treeTable>
+
+            <p:treeTable value="#{ttEditView.root2}" editable="true" editMode="cell" var="document" editInitEvent="dblclick" style="margin-bottom:20px">
+                <f:facet name="header">
+                    Cell Editing can be triggered by a custom event, like double click (dblclick)
+                </f:facet>
+                
+                <p:ajax event="cellEdit" listener="#{ttEditView.onCellEdit}" update=":form:msgs" />
+
+                <p:column headerText="Name"> 
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.name}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.name}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+                <p:column headerText="Size">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.size}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.size}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+                <p:column headerText="Type">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.type}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.type}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+            </p:treeTable>
+
+            <p:treeTable value="#{ttEditView.root3}" editable="true" editMode="cell" var="document" editInitEvent="mouseover">
+                <f:facet name="header">
+                    Several client-side events can trigger a cell edition, for example mouseover
+                </f:facet>
+                
+                <p:ajax event="cellEdit" listener="#{ttEditView.onCellEdit}" update=":form:msgs" />
+
+                <p:column headerText="Name"> 
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.name}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.name}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+                <p:column headerText="Size">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.size}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.size}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+                <p:column headerText="Type">
+                    <p:cellEditor>
+                        <f:facet name="output"><h:outputText value="#{document.type}" /></f:facet>
+                        <f:facet name="input"><p:inputText value="#{document.type}" style="width:100%"/></f:facet>
+                    </p:cellEditor>
+                </p:column>
+            </p:treeTable>
+            
+         </h:form>
+        
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/ui/data/treetable/template.xhtml
+++ b/src/main/webapp/ui/data/treetable/template.xhtml
@@ -42,6 +42,9 @@
                 <li>
                     <a href="#{request.contextPath}/ui/data/treetable/paginator.xhtml">&bull; Paginator</a>
                 </li>
+                <li>
+                    <a href="#{request.contextPath}/ui/data/treetable/editInitEvent.xhtml">&bull; editInitEvent</a>
+                </li>
             </ul>
         </div>
     </ui:define>


### PR DESCRIPTION
Hi, this PR covers the usage of new `editInitEvent` attribute of `p:treetable`'s as requested in https://github.com/primefaces/primefaces/issues/5182 and implemented in https://github.com/primefaces/primefaces/pull/6004 .

In addition this PR also introduces a showcase entry demonstrating the usage of `editInitEvent` in `p:datatable`'s.