### PR TITLE
Showcase - don't reference shaded artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <mojarra.version>2.3.14</mojarra.version>
         <myfaces.version>2.3.6</myfaces.version>
         <jetty.version>9.4.29.v20200521</jetty.version>
+        <org.json.version>20200518</org.json.version>
     </properties>
 
     <dependencies>
@@ -177,6 +178,13 @@
             <groupId>org.ehcache</groupId>
             <artifactId>ehcache</artifactId>
             <version>3.6.1</version>
+        </dependency>
+
+        <!-- org.json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${org.json.version}</version>
         </dependency>
 
         <!-- HTML sanitizer for the textEditor -->

--- a/src/main/java/org/primefaces/showcase/view/misc/PrimeIconsView.java
+++ b/src/main/java/org/primefaces/showcase/view/misc/PrimeIconsView.java
@@ -15,9 +15,9 @@
  */
 package org.primefaces.showcase.view.misc;
 
-import org.primefaces.shaded.json.JSONArray;
-import org.primefaces.shaded.json.JSONException;
-import org.primefaces.shaded.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;


### PR DESCRIPTION
The showcase is referencing shaded in references,  rather than testing the external implementation of a later/earlier version