### PR TITLE
Update client API links

### DIFF
--- a/src/main/webapp/WEB-INF/template.xhtml
+++ b/src/main/webapp/WEB-INF/template.xhtml
@@ -72,7 +72,13 @@
                                 </a>
                             </ui:fragment>
                             <ui:fragment rendered="#{not empty widgetLink}">
-                                <a class="documentation-link" href="https://primefaces.github.io/primefaces/jsdocs/classes/primefaces.widget.#{widgetLink}.html" target="_blank">
+                                <a class="documentation-link" href="https://primefaces.github.io/primefaces/jsdocs/classes/src_primefaces.primefaces.widget.#{widgetLink}.html#{not empty widgetLinkHash ? '#'.concat(widgetLinkHash) : ''}" target="_blank">
+                                    <i class="pi pi-external-link"></i> 
+                                    <span>CLIENT API</span>
+                                </a>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{not empty primefacesClientApiLink}">
+                                <a class="documentation-link" href="https://primefaces.github.io/primefaces/jsdocs/#{primefacesClientApiLink}" target="_blank">
                                     <i class="pi pi-external-link"></i> 
                                     <span>CLIENT API</span>
                                 </a>

--- a/src/main/webapp/ui/ajax/basic.xhtml
+++ b/src/main/webapp/ui/ajax/basic.xhtml
@@ -14,6 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/core/ajaxRendering"/>
+    <ui:param name="primefacesClientApiLink" value="modules/src_primefaces.primefaces.ajax.html" />
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/ajax/poll.xhtml
+++ b/src/main/webapp/ui/ajax/poll.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/poll"/>
-    <ui:param name="widgetLink" value="poll"/>
+    <ui:param name="widgetLink" value="poll-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/ajax/status.xhtml
+++ b/src/main/webapp/ui/ajax/status.xhtml
@@ -24,7 +24,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/ajaxstatus"/>
-    <ui:param name="widgetLink" value="ajaxstatus"/>
+    <ui:param name="widgetLink" value="ajaxstatus-1"/>
 
     <ui:define name="implementation">
         <div class="card text-secondary">

--- a/src/main/webapp/ui/button/splitButton.xhtml
+++ b/src/main/webapp/ui/button/splitButton.xhtml
@@ -22,7 +22,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/splitbutton"/>
-    <ui:param name="widgetLink" value="splitbutton"/>
+    <ui:param name="widgetLink" value="splitbutton-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/animate.xhtml
+++ b/src/main/webapp/ui/chart/animate.xhtml
@@ -26,7 +26,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/area.xhtml
+++ b/src/main/webapp/ui/chart/area.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/bar.xhtml
+++ b/src/main/webapp/ui/chart/bar.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/bubble.xhtml
+++ b/src/main/webapp/ui/chart/bubble.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/combined.xhtml
+++ b/src/main/webapp/ui/chart/combined.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/date.xhtml
+++ b/src/main/webapp/ui/chart/date.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/donut.xhtml
+++ b/src/main/webapp/ui/chart/donut.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/export.xhtml
+++ b/src/main/webapp/ui/chart/export.xhtml
@@ -28,7 +28,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/interactive.xhtml
+++ b/src/main/webapp/ui/chart/interactive.xhtml
@@ -22,7 +22,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/line.xhtml
+++ b/src/main/webapp/ui/chart/line.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/live.xhtml
+++ b/src/main/webapp/ui/chart/live.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/metergauge.xhtml
+++ b/src/main/webapp/ui/chart/metergauge.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/multiaxis.xhtml
+++ b/src/main/webapp/ui/chart/multiaxis.xhtml
@@ -10,7 +10,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="description">
         Up to 9 axes (xaxis-x9axis, yaxis-y9axis) can be displayed on the same chart.

--- a/src/main/webapp/ui/chart/ohlc.xhtml
+++ b/src/main/webapp/ui/chart/ohlc.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/pie.xhtml
+++ b/src/main/webapp/ui/chart/pie.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/responsive.xhtml
+++ b/src/main/webapp/ui/chart/responsive.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chart/zoom.xhtml
+++ b/src/main/webapp/ui/chart/zoom.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chart"/>
-    <ui:param name="widgetLink" value="chart"/>
+    <ui:param name="widgetLink" value="chart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/bar/bar.xhtml
+++ b/src/main/webapp/ui/chartjs/bar/bar.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=barchart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="barchart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/bubble.xhtml
+++ b/src/main/webapp/ui/chartjs/bubble.xhtml
@@ -12,7 +12,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=bubblechart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="bubblechart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/donut.xhtml
+++ b/src/main/webapp/ui/chartjs/donut.xhtml
@@ -12,7 +12,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=donutchart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="donutchart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/export.xhtml
+++ b/src/main/webapp/ui/chartjs/export.xhtml
@@ -27,7 +27,8 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=export"/>
-	<ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="basechart-1"/>
+    <ui:param name="widgetLinkHash" value="exportasimage"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/interactive.xhtml
+++ b/src/main/webapp/ui/chartjs/interactive.xhtml
@@ -13,7 +13,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=interactive-chart"/>
-    <ui:param name="widgetLink" value="charts?id=interactive-chart"/>
+    <ui:param name="widgetLink" value="basechart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/line.xhtml
+++ b/src/main/webapp/ui/chartjs/line.xhtml
@@ -20,7 +20,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=linechart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="linechart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/mixed.xhtml
+++ b/src/main/webapp/ui/chartjs/mixed.xhtml
@@ -12,7 +12,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=mixed-chart"/>
-    <ui:param name="widgetLink" value="charts?id=mixed-chart"/>
+    <ui:param name="widgetLink" value="basechart-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/pie.xhtml
+++ b/src/main/webapp/ui/chartjs/pie.xhtml
@@ -12,7 +12,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=piechart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="piechart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/polararea.xhtml
+++ b/src/main/webapp/ui/chartjs/polararea.xhtml
@@ -12,7 +12,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=polarareachart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="polarareachart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/radar.xhtml
+++ b/src/main/webapp/ui/chartjs/radar.xhtml
@@ -24,7 +24,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts?id=radarchart"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="radarchart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/chartjs/scatter.xhtml
+++ b/src/main/webapp/ui/chartjs/scatter.xhtml
@@ -20,7 +20,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/charts"/>
-    <ui:param name="widgetLink" value="charts"/>
+    <ui:param name="widgetLink" value="scatterchart"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/csv/custom.xhtml
+++ b/src/main/webapp/ui/csv/custom.xhtml
@@ -59,6 +59,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/core/clientsidevalidation?id=extending-csv"/>
+    <ui:param name="primefacesClientApiLink" value="modules/src_primefaces.primefaces.html#validator-1" />
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/carousel.xhtml
+++ b/src/main/webapp/ui/data/carousel.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/carousel"/>
-    <ui:param name="widgetLink" value="carousel"/>
+    <ui:param name="widgetLink" value="carousel-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/dataexporter/basic.xhtml
+++ b/src/main/webapp/ui/data/dataexporter/basic.xhtml
@@ -16,7 +16,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataexporter"/>
-    <ui:param name="widgetLink" value="dataexporter"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/dataexporter/customizedDocuments.xhtml
+++ b/src/main/webapp/ui/data/dataexporter/customizedDocuments.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataexporter"/>
-    <ui:param name="widgetLink" value="dataexporter"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/dataexporter/excludeColumns.xhtml
+++ b/src/main/webapp/ui/data/dataexporter/excludeColumns.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataexporter"/>
-    <ui:param name="widgetLink" value="dataexporter"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/dataexporter/lazy.xhtml
+++ b/src/main/webapp/ui/data/dataexporter/lazy.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataexporter"/>
-    <ui:param name="widgetLink" value="dataexporter"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datascroller/basic.xhtml
+++ b/src/main/webapp/ui/data/datascroller/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datascroller"/>
-    <ui:param name="widgetLink" value="datascroller"/>
+    <ui:param name="widgetLink" value="datascroller-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datascroller/inline.xhtml
+++ b/src/main/webapp/ui/data/datascroller/inline.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datascroller"/>
-    <ui:param name="widgetLink" value="datascroller"/>
+    <ui:param name="widgetLink" value="datascroller-1"/>
 
     <ui:define name="implementation">
         <div class="product card">

--- a/src/main/webapp/ui/data/datascroller/loader.xhtml
+++ b/src/main/webapp/ui/data/datascroller/loader.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datascroller"/>
-    <ui:param name="widgetLink" value="datascroller" />
+    <ui:param name="widgetLink" value="datascroller-1" />
 
     <ui:define name="implementation">
         <div class="product card">

--- a/src/main/webapp/ui/data/datatable/addRow.xhtml
+++ b/src/main/webapp/ui/data/datatable/addRow.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/basic.xhtml
+++ b/src/main/webapp/ui/data/datatable/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable" />
-    <ui:param name="widgetLink" value="datatable" />
+    <ui:param name="widgetLink" value="datatable-1" />
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/data/datatable/columnResize.xhtml
+++ b/src/main/webapp/ui/data/datatable/columnResize.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/columnToggler.xhtml
+++ b/src/main/webapp/ui/data/datatable/columnToggler.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/columns.xhtml
+++ b/src/main/webapp/ui/data/datatable/columns.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/contextMenu.xhtml
+++ b/src/main/webapp/ui/data/datatable/contextMenu.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/crud.xhtml
+++ b/src/main/webapp/ui/data/datatable/crud.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/data/datatable/displayPriority.xhtml
+++ b/src/main/webapp/ui/data/datatable/displayPriority.xhtml
@@ -13,7 +13,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/edit.xhtml
+++ b/src/main/webapp/ui/data/datatable/edit.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/expansion.xhtml
+++ b/src/main/webapp/ui/data/datatable/expansion.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/facets.xhtml
+++ b/src/main/webapp/ui/data/datatable/facets.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/field.xhtml
+++ b/src/main/webapp/ui/data/datatable/field.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable" />
-    <ui:param name="widgetLink" value="datatable" />
+    <ui:param name="widgetLink" value="datatable-1" />
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/data/datatable/filter.xhtml
+++ b/src/main/webapp/ui/data/datatable/filter.xhtml
@@ -23,7 +23,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/gridlines.xhtml
+++ b/src/main/webapp/ui/data/datatable/gridlines.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable" />
-    <ui:param name="widgetLink" value="datatable" />
+    <ui:param name="widgetLink" value="datatable-1" />
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/data/datatable/group.xhtml
+++ b/src/main/webapp/ui/data/datatable/group.xhtml
@@ -13,7 +13,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/lazy.xhtml
+++ b/src/main/webapp/ui/data/datatable/lazy.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/multiViewState.xhtml
+++ b/src/main/webapp/ui/data/datatable/multiViewState.xhtml
@@ -28,7 +28,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable" />
-    <ui:param name="widgetLink" value="datatable" />
+    <ui:param name="widgetLink" value="datatable-1" />
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/data/datatable/paginator.xhtml
+++ b/src/main/webapp/ui/data/datatable/paginator.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/reorder.xhtml
+++ b/src/main/webapp/ui/data/datatable/reorder.xhtml
@@ -13,7 +13,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/responsive.xhtml
+++ b/src/main/webapp/ui/data/datatable/responsive.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/rowColor.xhtml
+++ b/src/main/webapp/ui/data/datatable/rowColor.xhtml
@@ -24,7 +24,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/rowGroup.xhtml
+++ b/src/main/webapp/ui/data/datatable/rowGroup.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/rtl.xhtml
+++ b/src/main/webapp/ui/data/datatable/rtl.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/datatable/scroll.xhtml
+++ b/src/main/webapp/ui/data/datatable/scroll.xhtml
@@ -26,7 +26,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/selection.xhtml
+++ b/src/main/webapp/ui/data/datatable/selection.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/size.xhtml
+++ b/src/main/webapp/ui/data/datatable/size.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable" />
-    <ui:param name="widgetLink" value="datatable" />
+    <ui:param name="widgetLink" value="datatable-1" />
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/data/datatable/sort.xhtml
+++ b/src/main/webapp/ui/data/datatable/sort.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/data/datatable/sticky.xhtml
+++ b/src/main/webapp/ui/data/datatable/sticky.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable"/>
-    <ui:param name="widgetLink" value="datatable"/>
+    <ui:param name="widgetLink" value="datatable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/datatable/striped.xhtml
+++ b/src/main/webapp/ui/data/datatable/striped.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datatable" />
-    <ui:param name="widgetLink" value="datatable" />
+    <ui:param name="widgetLink" value="datatable-1" />
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/data/dataview/basic.xhtml
+++ b/src/main/webapp/ui/data/dataview/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataview"/>
-    <ui:param name="widgetLink" value="dataview"/>
+    <ui:param name="widgetLink" value="dataview-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/dataview/lazy.xhtml
+++ b/src/main/webapp/ui/data/dataview/lazy.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataview"/>
-    <ui:param name="widgetLink" value="dataview"/>
+    <ui:param name="widgetLink" value="dataview-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/dataview/multiViewState.xhtml
+++ b/src/main/webapp/ui/data/dataview/multiViewState.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataview"/>
-    <ui:param name="widgetLink" value="dataview"/>
+    <ui:param name="widgetLink" value="dataview-1"/>
 
     <ui:define name="implementation">
         <div class="product card">

--- a/src/main/webapp/ui/data/dataview/responsive.xhtml
+++ b/src/main/webapp/ui/data/dataview/responsive.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dataview"/>
-    <ui:param name="widgetLink" value="dataview"/>
+    <ui:param name="widgetLink" value="dataview-1"/>
 
     <ui:define name="implementation">
         <div class="product card">

--- a/src/main/webapp/ui/data/diagram/basic.xhtml
+++ b/src/main/webapp/ui/data/diagram/basic.xhtml
@@ -27,7 +27,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/diagram"/>
-    <ui:param name="widgetLink" value="diagram"/>
+    <ui:param name="widgetLink" value="diagram-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/diagram/editable.xhtml
+++ b/src/main/webapp/ui/data/diagram/editable.xhtml
@@ -35,7 +35,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/diagram"/>
-    <ui:param name="widgetLink" value="diagram"/>
+    <ui:param name="widgetLink" value="diagram-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/diagram/flowchart.xhtml
+++ b/src/main/webapp/ui/data/diagram/flowchart.xhtml
@@ -47,7 +47,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/diagram"/>
-    <ui:param name="widgetLink" value="diagram"/>
+    <ui:param name="widgetLink" value="diagram-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/diagram/hierarchical.xhtml
+++ b/src/main/webapp/ui/data/diagram/hierarchical.xhtml
@@ -35,7 +35,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/diagram"/>
-    <ui:param name="widgetLink" value="diagram"/>
+    <ui:param name="widgetLink" value="diagram-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/diagram/statemachine.xhtml
+++ b/src/main/webapp/ui/data/diagram/statemachine.xhtml
@@ -46,7 +46,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/diagram"/>
-    <ui:param name="widgetLink" value="diagram"/>
+    <ui:param name="widgetLink" value="diagram-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/addMarkers.xhtml
+++ b/src/main/webapp/ui/data/gmap/addMarkers.xhtml
@@ -53,7 +53,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/gmap/basic.xhtml
+++ b/src/main/webapp/ui/data/gmap/basic.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/circles.xhtml
+++ b/src/main/webapp/ui/data/gmap/circles.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/controls.xhtml
+++ b/src/main/webapp/ui/data/gmap/controls.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/draggableMarkers.xhtml
+++ b/src/main/webapp/ui/data/gmap/draggableMarkers.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/event.xhtml
+++ b/src/main/webapp/ui/data/gmap/event.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/geocode.xhtml
+++ b/src/main/webapp/ui/data/gmap/geocode.xhtml
@@ -30,7 +30,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/gmap/infoWindow.xhtml
+++ b/src/main/webapp/ui/data/gmap/infoWindow.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/mapDialog.xhtml
+++ b/src/main/webapp/ui/data/gmap/mapDialog.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/gmap/markerSelection.xhtml
+++ b/src/main/webapp/ui/data/gmap/markerSelection.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/markers.xhtml
+++ b/src/main/webapp/ui/data/gmap/markers.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/polygons.xhtml
+++ b/src/main/webapp/ui/data/gmap/polygons.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/polylines.xhtml
+++ b/src/main/webapp/ui/data/gmap/polylines.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/rectangles.xhtml
+++ b/src/main/webapp/ui/data/gmap/rectangles.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/gmap/street.xhtml
+++ b/src/main/webapp/ui/data/gmap/street.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/gmap"/>
-    <ui:param name="widgetLink" value="gmap"/>
+    <ui:param name="widgetLink" value="gmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/mindmap.xhtml
+++ b/src/main/webapp/ui/data/mindmap.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/mindmap"/>
-    <ui:param name="widgetLink" value="mindmap"/>
+    <ui:param name="widgetLink" value="mindmap-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/pickList.xhtml
+++ b/src/main/webapp/ui/data/pickList.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/picklist"/>
-    <ui:param name="widgetLink" value="picklist"/>
+    <ui:param name="widgetLink" value="picklist-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/repeat.xhtml
+++ b/src/main/webapp/ui/data/repeat.xhtml
@@ -31,7 +31,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/repeat"/>
-    <ui:param name="widgetLink" value="repeat"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/schedule/basic.xhtml
+++ b/src/main/webapp/ui/data/schedule/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/schedule"/>
-    <ui:param name="widgetLink" value="schedule"/>
+    <ui:param name="widgetLink" value="schedule-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/schedule/configuration.xhtml
+++ b/src/main/webapp/ui/data/schedule/configuration.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/schedule"/>
-    <ui:param name="widgetLink" value="schedule"/>
+    <ui:param name="widgetLink" value="schedule-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/schedule/extender.xhtml
+++ b/src/main/webapp/ui/data/schedule/extender.xhtml
@@ -18,7 +18,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/schedule"/>
-    <ui:param name="widgetLink" value="schedule"/>
+    <ui:param name="widgetLink" value="schedule-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/schedule/lazy.xhtml
+++ b/src/main/webapp/ui/data/schedule/lazy.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/schedule"/>
-    <ui:param name="widgetLink" value="schedule"/>
+    <ui:param name="widgetLink" value="schedule-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/schedule/localization.xhtml
+++ b/src/main/webapp/ui/data/schedule/localization.xhtml
@@ -47,7 +47,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/schedule"/>
-    <ui:param name="widgetLink" value="schedule"/>
+    <ui:param name="widgetLink" value="schedule-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/timeline/allEvents.xhtml
+++ b/src/main/webapp/ui/data/timeline/allEvents.xhtml
@@ -77,7 +77,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/data/timeline/basic.xhtml
+++ b/src/main/webapp/ui/data/timeline/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/data/timeline/custom.xhtml
+++ b/src/main/webapp/ui/data/timeline/custom.xhtml
@@ -77,7 +77,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/data/timeline/dragdrop.xhtml
+++ b/src/main/webapp/ui/data/timeline/dragdrop.xhtml
@@ -33,7 +33,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/timeline/editServer.xhtml
+++ b/src/main/webapp/ui/data/timeline/editServer.xhtml
@@ -41,7 +41,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/timeline/grouping.xhtml
+++ b/src/main/webapp/ui/data/timeline/grouping.xhtml
@@ -39,7 +39,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/timeline/lazy.xhtml
+++ b/src/main/webapp/ui/data/timeline/lazy.xhtml
@@ -29,7 +29,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/timeline/limitRange.xhtml
+++ b/src/main/webapp/ui/data/timeline/limitRange.xhtml
@@ -20,7 +20,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/data/timeline/linked.xhtml
+++ b/src/main/webapp/ui/data/timeline/linked.xhtml
@@ -46,7 +46,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/timeline/nestedGrouping.xhtml
+++ b/src/main/webapp/ui/data/timeline/nestedGrouping.xhtml
@@ -39,7 +39,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/timeline"/>
-    <ui:param name="widgetLink" value="timeline"/>
+    <ui:param name="widgetLink" value="timeline-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/tree/animate.xhtml
+++ b/src/main/webapp/ui/data/tree/animate.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/tree?id=vertial-tree"/>
-    <ui:param name="widgetLink" value="verticaltree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/tree/basic.xhtml
+++ b/src/main/webapp/ui/data/tree/basic.xhtml
@@ -14,6 +14,9 @@
         available.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
 
         <h:form>

--- a/src/main/webapp/ui/data/tree/contextMenu.xhtml
+++ b/src/main/webapp/ui/data/tree/contextMenu.xhtml
@@ -13,6 +13,9 @@
         ContextMenu has special integration with Tree. Even different menus can be assigned to different node types by matching node types.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form>

--- a/src/main/webapp/ui/data/tree/dragdrop.xhtml
+++ b/src/main/webapp/ui/data/tree/dragdrop.xhtml
@@ -13,6 +13,9 @@
         Nodes can be reordered within the same tree or transferred between multiple trees using drag and drop.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form id="form">

--- a/src/main/webapp/ui/data/tree/events.xhtml
+++ b/src/main/webapp/ui/data/tree/events.xhtml
@@ -13,6 +13,9 @@
         An ajax behavior callback is provided for each event such as expand, collapse, select and unselect.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form id="form">

--- a/src/main/webapp/ui/data/tree/filter.xhtml
+++ b/src/main/webapp/ui/data/tree/filter.xhtml
@@ -13,6 +13,9 @@
         Filtering updates the node based on the constraints.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form>

--- a/src/main/webapp/ui/data/tree/icon.xhtml
+++ b/src/main/webapp/ui/data/tree/icon.xhtml
@@ -13,6 +13,9 @@
         Each node type can have different icons.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form>

--- a/src/main/webapp/ui/data/tree/lazyloading.xhtml
+++ b/src/main/webapp/ui/data/tree/lazyloading.xhtml
@@ -13,6 +13,9 @@
         This example shows how to implement lazy loading of child nodes - which is essential for big models.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form id="form">

--- a/src/main/webapp/ui/data/tree/rtl.xhtml
+++ b/src/main/webapp/ui/data/tree/rtl.xhtml
@@ -13,6 +13,9 @@
         Tree has built-in support for RTL languages.
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form>

--- a/src/main/webapp/ui/data/tree/selection.xhtml
+++ b/src/main/webapp/ui/data/tree/selection.xhtml
@@ -13,6 +13,9 @@
         Tree provides three selection modes, "single", "multiple" and "checkbox".
     </ui:define>
 
+    <ui:param name="documentationLink" value="/components/tree"/>
+    <ui:param name="widgetLink" value="verticaltree-1"/>
+
     <ui:define name="implementation">
         <div class="card">
             <h:form>

--- a/src/main/webapp/ui/data/treetable/basic.xhtml
+++ b/src/main/webapp/ui/data/treetable/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/columns.xhtml
+++ b/src/main/webapp/ui/data/treetable/columns.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/contextMenu.xhtml
+++ b/src/main/webapp/ui/data/treetable/contextMenu.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/displayPriority.xhtml
+++ b/src/main/webapp/ui/data/treetable/displayPriority.xhtml
@@ -31,7 +31,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/edit.xhtml
+++ b/src/main/webapp/ui/data/treetable/edit.xhtml
@@ -25,7 +25,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/treetable/events.xhtml
+++ b/src/main/webapp/ui/data/treetable/events.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/filter.xhtml
+++ b/src/main/webapp/ui/data/treetable/filter.xhtml
@@ -26,7 +26,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card ui-fluid">

--- a/src/main/webapp/ui/data/treetable/gridlines.xhtml
+++ b/src/main/webapp/ui/data/treetable/gridlines.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/multiViewState.xhtml
+++ b/src/main/webapp/ui/data/treetable/multiViewState.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/paginator.xhtml
+++ b/src/main/webapp/ui/data/treetable/paginator.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/resize.xhtml
+++ b/src/main/webapp/ui/data/treetable/resize.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/treetable/responsive.xhtml
+++ b/src/main/webapp/ui/data/treetable/responsive.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/scroll.xhtml
+++ b/src/main/webapp/ui/data/treetable/scroll.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/treetable/selection.xhtml
+++ b/src/main/webapp/ui/data/treetable/selection.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/data/treetable/size.xhtml
+++ b/src/main/webapp/ui/data/treetable/size.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/data/treetable/sort.xhtml
+++ b/src/main/webapp/ui/data/treetable/sort.xhtml
@@ -22,7 +22,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/treetable"/>
-    <ui:param name="widgetLink" value="treetable"/>
+    <ui:param name="widgetLink" value="treetable-1"/>
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/dnd/custom.xhtml
+++ b/src/main/webapp/ui/dnd/custom.xhtml
@@ -80,6 +80,8 @@
         Column headers can also be moved back to the tree.
     </ui:define>
 
+    <ui:param name="primefacesClientApiLink" value="interfaces/src_primefaces.jquery-1.html#draggable" />
+
     <ui:define name="implementation">
         <div class="card">
             <h:form id="form">

--- a/src/main/webapp/ui/file/upload/auto.xhtml
+++ b/src/main/webapp/ui/file/upload/auto.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload?id=auto-upload"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/file/upload/basic.xhtml
+++ b/src/main/webapp/ui/file/upload/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/file/upload/basicAuto.xhtml
+++ b/src/main/webapp/ui/file/upload/basicAuto.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/file/upload/dnd.xhtml
+++ b/src/main/webapp/ui/file/upload/dnd.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/file/upload/multiple.xhtml
+++ b/src/main/webapp/ui/file/upload/multiple.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload?id=multiple-uploads"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/file/upload/single.xhtml
+++ b/src/main/webapp/ui/file/upload/single.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/file/upload/tooltips.xhtml
+++ b/src/main/webapp/ui/file/upload/tooltips.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/fileupload"/>
-    <ui:param name="widgetLink" value="fileupload"/>
+    <ui:param name="widgetLink" value="fileupload-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/autoComplete.xhtml
+++ b/src/main/webapp/ui/input/autoComplete.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/autocomplete"/>
-    <ui:param name="widgetLink" value="autocomplete"/>
+    <ui:param name="widgetLink" value="autocomplete-1"/>
 
     <ui:define name="implementation">
         <div class="card ui-fluid ">

--- a/src/main/webapp/ui/input/calendar/calendar.xhtml
+++ b/src/main/webapp/ui/input/calendar/calendar.xhtml
@@ -51,7 +51,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/calendar"/>
-    <ui:param name="widgetLink" value="calendar"/>
+    <ui:param name="widgetLink" value="calendar-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/calendar/calendarJava8.xhtml
+++ b/src/main/webapp/ui/input/calendar/calendarJava8.xhtml
@@ -51,7 +51,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/calendar"/>
-    <ui:param name="widgetLink" value="calendar"/>
+    <ui:param name="widgetLink" value="calendar-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/checkboxMenu.xhtml
+++ b/src/main/webapp/ui/input/checkboxMenu.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/selectcheckboxmenu"/>
-    <ui:param name="widgetLink" value="selectcheckboxmenu"/>
+    <ui:param name="widgetLink" value="selectcheckboxmenu-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/colorPicker.xhtml
+++ b/src/main/webapp/ui/input/colorPicker.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/colorpicker"/>
-    <ui:param name="widgetLink" value="colorpicker"/>
+    <ui:param name="widgetLink" value="colorpicker-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/datepicker/datePicker.xhtml
+++ b/src/main/webapp/ui/input/datepicker/datePicker.xhtml
@@ -90,7 +90,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datepicker"/>
-    <ui:param name="widgetLink" value="datepicker"/>
+    <ui:param name="widgetLink" value="datepicker-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
+++ b/src/main/webapp/ui/input/datepicker/datePickerJava8.xhtml
@@ -84,7 +84,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datepicker"/>
-    <ui:param name="widgetLink" value="datepicker"/>
+    <ui:param name="widgetLink" value="datepicker-1"/>
 
     <ui:define name="implementation">
         <h:form id="form">

--- a/src/main/webapp/ui/input/datepicker/metadata.xhtml
+++ b/src/main/webapp/ui/input/datepicker/metadata.xhtml
@@ -27,7 +27,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/datepicker"/>
-    <ui:param name="widgetLink" value="datepicker"/>
+    <ui:param name="widgetLink" value="datepicker-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/input/inplace.xhtml
+++ b/src/main/webapp/ui/input/inplace.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/inplace"/>
-    <ui:param name="widgetLink" value="inplace"/>
+    <ui:param name="widgetLink" value="inplace-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/inputNumber.xhtml
+++ b/src/main/webapp/ui/input/inputNumber.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/inputnumber"/>
-    <ui:param name="widgetLink" value="inputnumber"/>
+    <ui:param name="widgetLink" value="inputnumber-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/knob.xhtml
+++ b/src/main/webapp/ui/input/knob.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/knob"/>
-    <ui:param name="widgetLink" value="knob"/>
+    <ui:param name="widgetLink" value="knob-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/input/oneButton.xhtml
+++ b/src/main/webapp/ui/input/oneButton.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/selectonebutton"/>
-    <ui:param name="widgetLink" value="selectonebutton"/>
+    <ui:param name="widgetLink" value="selectonebutton-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/oneMenu.xhtml
+++ b/src/main/webapp/ui/input/oneMenu.xhtml
@@ -17,7 +17,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/selectonemenu"/>
-    <ui:param name="widgetLink" value="selectonemenu"/>
+    <ui:param name="widgetLink" value="selectonemenu-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/rating.xhtml
+++ b/src/main/webapp/ui/input/rating.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/rating"/>
-    <ui:param name="widgetLink" value="rating"/>
+    <ui:param name="widgetLink" value="rating-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/signature.xhtml
+++ b/src/main/webapp/ui/input/signature.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/signature"/>
-    <ui:param name="widgetLink" value="signature"/>
+    <ui:param name="widgetLink" value="signature-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/slider.xhtml
+++ b/src/main/webapp/ui/input/slider.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/slider"/>
-    <ui:param name="widgetLink" value="slider"/>
+    <ui:param name="widgetLink" value="slider-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/textEditor.xhtml
+++ b/src/main/webapp/ui/input/textEditor.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/texteditor"/>
-    <ui:param name="widgetLink" value="texteditor"/>
+    <ui:param name="widgetLink" value="texteditor-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/input/triStateCheckbox.xhtml
+++ b/src/main/webapp/ui/input/triStateCheckbox.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/tristatecheckbox"/>
-    <ui:param name="widgetLink" value="tristatecheckbox"/>
+    <ui:param name="widgetLink" value="tristatecheckbox-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/menu/breadcrumb.xhtml
+++ b/src/main/webapp/ui/menu/breadcrumb.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/breadcrumb"/>
-    <ui:param name="widgetLink" value="breadcrumb"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/menu/contextmenu/basic.xhtml
+++ b/src/main/webapp/ui/menu/contextmenu/basic.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/contextmenu"/>
-    <ui:param name="widgetLink" value="contextmenu"/>
+    <ui:param name="widgetLink" value="contextmenu-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/menu/contextmenu/target.xhtml
+++ b/src/main/webapp/ui/menu/contextmenu/target.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/contextmenu"/>
-    <ui:param name="widgetLink" value="contextmenu"/>
+    <ui:param name="widgetLink" value="contextmenu-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/menu/contextmenu/tiered.xhtml
+++ b/src/main/webapp/ui/menu/contextmenu/tiered.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/contextmenu"/>
-    <ui:param name="widgetLink" value="contextmenu"/>
+    <ui:param name="widgetLink" value="contextmenu-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/menu/steps.xhtml
+++ b/src/main/webapp/ui/menu/steps.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/steps"/>
-    <ui:param name="widgetLink" value="steps"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/menu/tieredMenu.xhtml
+++ b/src/main/webapp/ui/menu/tieredMenu.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/tieredmenu"/>
-    <ui:param name="widgetLink" value="tieredmenu"/>
+    <ui:param name="widgetLink" value="tieredmenu-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/message/messages.xhtml
+++ b/src/main/webapp/ui/message/messages.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/messages"/>
-    <ui:param name="widgetLink" value="messages"/>
+    <ui:param name="widgetLink" value="message"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/message/staticMessage.xhtml
+++ b/src/main/webapp/ui/message/staticMessage.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/staticmessage"/>
-    <ui:param name="widgetLink" value="staticmessage"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/misc/autoUpdate.xhtml
+++ b/src/main/webapp/ui/misc/autoUpdate.xhtml
@@ -15,7 +15,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/autoupdate"/>
-    <ui:param name="widgetLink" value="autoupdate"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/captcha.xhtml
+++ b/src/main/webapp/ui/misc/captcha.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/captcha"/>
-    <ui:param name="widgetLink" value="captcha"/>
+    <ui:param name="widgetLink" value="captcha-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/chip.xhtml
+++ b/src/main/webapp/ui/misc/chip.xhtml
@@ -23,6 +23,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/chip"/>
+    <ui:param name="widgetLink" value="chip" />
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/clock.xhtml
+++ b/src/main/webapp/ui/misc/clock.xhtml
@@ -23,7 +23,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/clock"/>
-    <ui:param name="widgetLink" value="clock"/>
+    <ui:param name="widgetLink" value="clock-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/effect.xhtml
+++ b/src/main/webapp/ui/misc/effect.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/effect"/>
-    <ui:param name="widgetLink" value="effect"/>
+    <ui:param name="widgetLink" value="effect-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/feedReader.xhtml
+++ b/src/main/webapp/ui/misc/feedReader.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/feedreader"/>
-    <ui:param name="widgetLink" value="feedreader"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/focus.xhtml
+++ b/src/main/webapp/ui/misc/focus.xhtml
@@ -15,7 +15,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/focus"/>
-    <ui:param name="widgetLink" value="focus"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/hotkey.xhtml
+++ b/src/main/webapp/ui/misc/hotkey.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/hotkey"/>
-    <ui:param name="widgetLink" value="hotkey"/>
+    <ui:param name="primefacesClientApiLink" value="interfaces/src_primefaces.jquerystatic.html#hotkeys"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/idleMonitor.xhtml
+++ b/src/main/webapp/ui/misc/idleMonitor.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/idlemonitor"/>
-    <ui:param name="widgetLink" value="idlemonitor"/>
+    <ui:param name="widgetLink" value="idlemonitor-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/log.xhtml
+++ b/src/main/webapp/ui/misc/log.xhtml
@@ -24,7 +24,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/log"/>
-    <ui:param name="widgetLink" value="log"/>
+    <ui:param name="widgetLink" value="log-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/outputLabel.xhtml
+++ b/src/main/webapp/ui/misc/outputLabel.xhtml
@@ -15,7 +15,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/outputlabel"/>
-    <ui:param name="widgetLink" value="outputlabel"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/printer.xhtml
+++ b/src/main/webapp/ui/misc/printer.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/printer"/>
-    <ui:param name="widgetLink" value="printer" />
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/resetInput.xhtml
+++ b/src/main/webapp/ui/misc/resetInput.xhtml
@@ -15,7 +15,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/resetinput"/>
-    <ui:param name="widgetLink" value="resetinput"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/resizable.xhtml
+++ b/src/main/webapp/ui/misc/resizable.xhtml
@@ -13,7 +13,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/resizable"/>
-    <ui:param name="widgetLink" value="resizable"/>
+    <ui:param name="widgetLink" value="resizable-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/scrollTop.xhtml
+++ b/src/main/webapp/ui/misc/scrollTop.xhtml
@@ -33,6 +33,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/scrolltop"/>
+    <ui:param name="widgetLink" value="scrolltop" />
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/misc/sticky.xhtml
+++ b/src/main/webapp/ui/misc/sticky.xhtml
@@ -29,7 +29,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/sticky"/>
-    <ui:param name="widgetLink" value="sticky"/>
+    <ui:param name="widgetLink" value="sticky-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/multimedia/audio.xhtml
+++ b/src/main/webapp/ui/multimedia/audio.xhtml
@@ -18,7 +18,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/audio"/>
-    <ui:param name="widgetLink" value="audio"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/multimedia/barcode.xhtml
+++ b/src/main/webapp/ui/multimedia/barcode.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/barcode"/>
-    <ui:param name="widgetLink" value="barcode"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/multimedia/graphicImage.xhtml
+++ b/src/main/webapp/ui/multimedia/graphicImage.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/graphicimage"/>
-    <ui:param name="widgetLink" value="graphicimage"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/multimedia/media.xhtml
+++ b/src/main/webapp/ui/multimedia/media.xhtml
@@ -17,7 +17,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/media"/>
-    <ui:param name="widgetLink" value="media"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/multimedia/photocam/deviceSelection.xhtml
+++ b/src/main/webapp/ui/multimedia/photocam/deviceSelection.xhtml
@@ -15,7 +15,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/photocam"/>
-    <ui:param name="widgetLink" value="photocam"/>
+    <ui:param name="widgetLink" value="photocam-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/multimedia/photocam/photoCam.xhtml
+++ b/src/main/webapp/ui/multimedia/photocam/photoCam.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/photocam"/>
-    <ui:param name="widgetLink" value="photocam"/>
+    <ui:param name="widgetLink" value="photocam-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/multimedia/video.xhtml
+++ b/src/main/webapp/ui/multimedia/video.xhtml
@@ -18,7 +18,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/video"/>
-    <ui:param name="widgetLink" value="video"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/overlay/confirmDialog.xhtml
+++ b/src/main/webapp/ui/overlay/confirmDialog.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/confirm"/>
-    <ui:param name="widgetLink" value="confirm"/>
+    <ui:param name="widgetLink" value="confirmdialog-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/overlay/confirmPopup.xhtml
+++ b/src/main/webapp/ui/overlay/confirmPopup.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/confirm"/>
-    <ui:param name="widgetLink" value="confirm"/>
+    <ui:param name="widgetLink" value="confirmpopup-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/overlay/dialog.xhtml
+++ b/src/main/webapp/ui/overlay/dialog.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/dialog"/>
-    <ui:param name="widgetLink" value="dialog"/>
+    <ui:param name="widgetLink" value="dialog-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/overlay/lightBox.xhtml
+++ b/src/main/webapp/ui/overlay/lightBox.xhtml
@@ -22,7 +22,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/lightbox"/>
-    <ui:param name="widgetLink" value="lightbox"/>
+    <ui:param name="widgetLink" value="lightbox-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/overlay/sidebar.xhtml
+++ b/src/main/webapp/ui/overlay/sidebar.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/sidebar"/>
-    <ui:param name="widgetLink" value="sidebar"/>
+    <ui:param name="widgetLink" value="sidebar-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/overlay/tooltip/tooltipGlobal.xhtml
+++ b/src/main/webapp/ui/overlay/tooltip/tooltipGlobal.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/tooltip"/>
-    <ui:param name="widgetLink" value="tooltip"/>
+    <ui:param name="widgetLink" value="tooltip-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/overlay/tooltip/tooltipOptions.xhtml
+++ b/src/main/webapp/ui/overlay/tooltip/tooltipOptions.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/tooltip"/>
-    <ui:param name="widgetLink" value="tooltip"/>
+    <ui:param name="widgetLink" value="tooltip-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/panel/notificationBar.xhtml
+++ b/src/main/webapp/ui/panel/notificationBar.xhtml
@@ -26,7 +26,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/notificationbar"/>
-    <ui:param name="widgetLink" value="notificationbar"/>
+    <ui:param name="widgetLink" value="notificationbar-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/panel/outputPanel.xhtml
+++ b/src/main/webapp/ui/panel/outputPanel.xhtml
@@ -16,7 +16,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/outputpanel"/>
-    <ui:param name="widgetLink" value="outputpanel"/>
+    <ui:param name="widgetLink" value="outputpanel-1"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/panel/panel.xhtml
+++ b/src/main/webapp/ui/panel/panel.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/panel"/>
-    <ui:param name="widgetLink" value="panel"/>
+    <ui:param name="widgetLink" value="panel-1"/>
 
     <ui:define name="implementation">
         <h:form>

--- a/src/main/webapp/ui/panel/panelGrid.xhtml
+++ b/src/main/webapp/ui/panel/panelGrid.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/panelgrid"/>
-    <ui:param name="widgetLink" value="panelgrid"/>
 
     <ui:define name="head">
         <style type="text/css">

--- a/src/main/webapp/ui/panel/splitter.xhtml
+++ b/src/main/webapp/ui/panel/splitter.xhtml
@@ -12,7 +12,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/splitter"/>
-    <ui:param name="widgetLink" value="splitter"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/panel/tabView.xhtml
+++ b/src/main/webapp/ui/panel/tabView.xhtml
@@ -14,7 +14,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/tabview"/>
-    <ui:param name="widgetLink" value="tabview"/>
+    <ui:param name="widgetLink" value="tabview-1"/>
 
     <ui:define name="implementation">
 

--- a/src/main/webapp/ui/panel/toolbar.xhtml
+++ b/src/main/webapp/ui/panel/toolbar.xhtml
@@ -14,7 +14,6 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/toolbar"/>
-    <ui:param name="widgetLink" value="toolbar"/>
 
     <ui:define name="implementation">
         <div class="card">

--- a/src/main/webapp/ui/panel/wizard.xhtml
+++ b/src/main/webapp/ui/panel/wizard.xhtml
@@ -47,7 +47,7 @@
     </ui:define>
 
     <ui:param name="documentationLink" value="/components/wizard"/>
-    <ui:param name="widgetLink" value="wizard"/>
+    <ui:param name="widgetLink" value="wizard-1"/>
 
     <ui:define name="implementation">
         <div class="card">


### PR DESCRIPTION
I updated the client API links for the JSDocs page.

I also removed the client API on a few pages for which no JSDocs (ever) existed. 

PS: Might just be a local issue, but I noticed that when I had the showcase running I'd come across some pages that resulted in a 404 -- when I clicked on the same page again it would load again... strange 